### PR TITLE
remove console.log

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,6 @@ function findCmd (cmds, cb) {
 
   var tasks = cmds.map(function (cmd, i) {
     return function (cb) {
-      console.log(cmd)
       cp.exec(cmd + ' --version', function (err) {
         if (!err && (foundIndex === -1 || i < foundIndex)) {
           foundIndex = i


### PR DESCRIPTION
I assume this was left there by accident - so i removed it

Perhaps if there is an actual need to read into the search paths, it can be returned as a third arg?
