### PR TITLE
Add support for VLC in Flatpak on Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,8 @@ function getVLCPathLinux (cb) {
   var cmds = [
     '/usr/bin/vlc',
     '/usr/local/bin/vlc',
-    'vlc'
+    'vlc',
+    'flatpak run org.videolan.VLC'
   ]
   findCmd(cmds, cb)
 }


### PR DESCRIPTION
This PR adds the ability to find VLC even if it's installed only via Flatpak. This is the case on systems using rpm-ostree like [Fedora Silverblue](https://docs.fedoraproject.org/en-US/fedora-silverblue/) that have a readonly system partition and install all apps via Flatpak.